### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,6 +5,9 @@ on:
       - v*
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   EAS_BUILD_ARGS: --non-interactive --profile production --local
 


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/app/security/code-scanning/3](https://github.com/djoamersfoort/app/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/ios.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
Best minimal fix without changing functionality: set:

- `contents: read`

This is the CodeQL-recommended baseline and is sufficient for the shown steps (checkout and build/upload actions that primarily rely on other secrets/tokens, not broad `GITHUB_TOKEN` write access).

Edit region: near the top of `.github/workflows/ios.yml`, after the `on:` block and before `env:` (or before `jobs:`).  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
