### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,9 @@ on:
       - v*
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   EAS_BUILD_ARGS: --non-interactive --profile production --local
 


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/app/security/code-scanning/2](https://github.com/djoamersfoort/app/security/code-scanning/2)

To fix this, add a top-level `permissions` block in `.github/workflows/android.yml` so all jobs in this workflow inherit minimal token access unless overridden.  
Best single change without altering functionality: add:

- `contents: read` (minimal recommended baseline for checkout and repository reads)

Place it near the top of the workflow (after `on:` or after `env:`), before `jobs:`. No imports, methods, or other definitions are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
