### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
       - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/app/security/code-scanning/1](https://github.com/djoamersfoort/app/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to the minimum required access.  
Best fix here: set workflow-level permissions to `contents: read` since the job only needs to read repository contents (for checkout and CI checks) and does not need write scopes.

**File to change:** `.github/workflows/pull-request.yml`  
**Change location:** near the top-level keys, after `on:` and before `jobs:` (or before/after `name:`/`on:` consistently).  
**No new imports/dependencies/methods** are needed—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
